### PR TITLE
Add UTF-8 charset to index.html

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:foo="http://www.w3.org/2000/svg">
   <head>
+    <meta charset="utf-8"/>
     <title>My Halogen App</title>
     <style>
       body {


### PR DESCRIPTION
I think this is a reasonable default, and it might prevent surprises down the road for users, like I encountered when trying to bundle d3.js, which includes a variable named [`ε = 1e-6`](https://www.cs.cmu.edu/~tom7/papers/epsilon.pdf). 