### PR TITLE
Update spago to non legacy version

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "devDependencies": {
     "parcel": "2.7.0",
     "purescript": "^0.15.4",
-    "spago": "^0.20.9"
+    "spago": "^0.93.0"
   },
   "scripts": {
     "build": "spago build",

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,4 +1,0 @@
-let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.15.4-20220816/packages.dhall sha256:8b4467b4b5041914f9b765779c8936d6d4c230b1f60eb64f6269c71812fd7e98
-
-in  upstream

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,5 +1,0 @@
-{ name = "halogen-project"
-, dependencies = [ "console", "effect", "halogen", "prelude" ]
-, packages = ./packages.dhall
-, sources = [ "src/**/*.purs", "test/**/*.purs" ]
-}

--- a/spago.yaml
+++ b/spago.yaml
@@ -1,0 +1,11 @@
+package:
+  dependencies:
+    - console
+    - effect
+    - halogen
+    - prelude
+  name: halogen-project
+workspace:
+  extraPackages: {}
+  packageSet:
+    url: https://raw.githubusercontent.com/purescript/package-sets/psc-0.15.4-20220816/packages.json


### PR DESCRIPTION
Newcomers to Purescript might be confused by the onging move in Spago between legacy and newer version, particularly since https://github.com/thomashoneyman/purescript-halogen-realworld switched to the newest spago (using yaml rather than dhall).

Using the latest Spago - while still in alpha I've yet to find any flaw with it - might be less confusing.